### PR TITLE
Allow date prop to be anything renderable

### DIFF
--- a/src/VerticalTimelineElement.js
+++ b/src/VerticalTimelineElement.js
@@ -82,7 +82,7 @@ VerticalTimelineElement.propTypes = {
   iconStyle: PropTypes.shape({}),
   iconOnClick: PropTypes.func,
   style: PropTypes.shape({}),
-  date: PropTypes.string,
+  date: PropTypes.node,
   position: PropTypes.string,
   visibilitySensorProps: PropTypes.shape({}),
 };


### PR DESCRIPTION
It allows to render a custom component around date

![image](https://user-images.githubusercontent.com/368155/46301046-82d3e280-c5a5-11e8-9605-2883a64f902c.png)

```jsx
    <VerticalTimelineElement
      position="right"
      date={
        <div>
          <div>2011 - present</div>
          <Amount>200€</Amount>
        </div>
      }
    >
      <h3 className="vertical-timeline-element-title">Creative Director</h3>
      <h4 className="vertical-timeline-element-subtitle">Miami, FL</h4>
      <p>Creative Direction, User Experience, Visual Design, Project Management, Team Leading</p>
    </VerticalTimelineElement>
```
