### PR TITLE
Change to use react-intersection-observer

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,10 +188,10 @@ Add extra style to root div element.
 
 Add extra class name to the text container.
 
-### `visibilitySensorProps={ Object }`
+### `intersectionObserverProps={ Object }`
 
-Custom props pass to VisibilitySensor component (default: { partialVisibility: true, offset: { bottom: 80 } }).
-*See [react-visibility-sensor](https://github.com/joshwnj/react-visibility-sensor) for more information.*
+Custom props pass to `useInView` component (default: { rootMargin: '0px 0px 40px 0px' }).
+*See [react-intersection-observer](https://github.com/thebuilder/react-intersection-observer) for more information.*
 
 
 ## Showcase
@@ -210,7 +210,7 @@ $ yarn start
 $ yarn test
 ```
 
-### Watch and Run the tests 
+### Watch and Run the tests
 ```code
 $ yarn test:watch
 ```

--- a/__tests__/VerticalTimelineElement_test.js
+++ b/__tests__/VerticalTimelineElement_test.js
@@ -3,7 +3,12 @@ import {
   renderIntoDocument,
   scryRenderedDOMComponentsWithClass,
 } from 'react-dom/test-utils';
+import { mockAllIsIntersecting } from 'react-intersection-observer/test-utils';
 import VerticalTimelineElement from '../src/VerticalTimelineElement';
+
+beforeEach(() => {
+  mockAllIsIntersecting(true);
+});
 
 describe('VerticalTimeline', () => {
   it('should have the vertical-timeline-element classname', () => {

--- a/__tests__/VerticalTimeline_test.js
+++ b/__tests__/VerticalTimeline_test.js
@@ -1,8 +1,13 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { expect } from 'chai';
+import { mockAllIsIntersecting } from 'react-intersection-observer/test-utils';
 
 import VerticalTimeline from '../src/VerticalTimeline';
+
+beforeEach(() => {
+  mockAllIsIntersecting(true);
+});
 
 describe('VerticalTimeline', () => {
   it('should have the vertical-timeline classname', () => {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Vertical timeline for React.js",
   "author": "Stéphane Monnot",
   "user": "stephane-monnot",
-  "version": "2.6.2",
+  "version": "3.0.0",
   "scripts": {
     "start": "catalog start docs",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,6 @@
   "dependencies": {
     "classnames": "^2.2.6",
     "prop-types": "^15.7.2",
-    "react-visibility-sensor": "^5.1.1"
+    "react-intersection-observer": "^8.26.2"
   }
 }

--- a/src/VerticalTimelineElement.js
+++ b/src/VerticalTimelineElement.js
@@ -134,6 +134,7 @@ VerticalTimelineElement.defaultProps = {
   id: '',
   style: null,
   date: '',
+  dateClassName: '',
   position: '',
   textClassName: '',
   visibilitySensorProps: { partialVisibility: true, offset: { bottom: 40 } },

--- a/src/VerticalTimelineElement.js
+++ b/src/VerticalTimelineElement.js
@@ -21,7 +21,11 @@ const VerticalTimelineElement = ({
   textClassName,
   intersectionObserverProps,
 }) => {
+  const [visible, setVisible] = useState(false);
   const [ref, inView] = useInView(intersectionObserverProps);
+  if (!visible && inView) {
+    setVisible(true);
+  }
 
   return (
     <div
@@ -42,8 +46,8 @@ const VerticalTimelineElement = ({
             iconClassName,
             'vertical-timeline-element-icon',
             {
-              'bounce-in': inView,
-              'is-hidden': !inView,
+              'bounce-in': visible,
+              'is-hidden': !visible,
             }
           )}
         >
@@ -56,8 +60,8 @@ const VerticalTimelineElement = ({
             textClassName,
             'vertical-timeline-element-content',
             {
-              'bounce-in': inView,
-              'is-hidden': !inView,
+              'bounce-in': visible,
+              'is-hidden': !visible,
             }
           )}
         >
@@ -100,8 +104,10 @@ VerticalTimelineElement.propTypes = {
   style: PropTypes.shape({}),
   textClassName: PropTypes.string,
   intersectionObserverProps: PropTypes.shape({
-    onChange: PropTypes.func,
+    root: PropTypes.object,
     rootMargin: PropTypes.string,
+    threshold: PropType.number,
+    triggerOnce: PropTypes.bool,
   }),
 };
 

--- a/src/VerticalTimelineElement.js
+++ b/src/VerticalTimelineElement.js
@@ -1,7 +1,7 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import VisibilitySensor from 'react-visibility-sensor';
+import { useInView } from 'react-intersection-observer';
 
 const VerticalTimelineElement = ({
   children,
@@ -19,23 +19,13 @@ const VerticalTimelineElement = ({
   position,
   style,
   textClassName,
-  visibilitySensorProps,
+  intersectionObserverProps,
 }) => {
-  const [visible, setVisible] = useState(false);
-  const onVisibilitySensorChange = isVisible => {
-    const { onChange } = visibilitySensorProps;
-
-    if (typeof onChange === 'function') {
-      onChange(isVisible);
-    }
-
-    if (isVisible) {
-      setVisible(true);
-    }
-  };
+  const [ref, inView] = useInView(intersectionObserverProps);
 
   return (
     <div
+      ref={ref}
       id={id}
       className={classNames(className, 'vertical-timeline-element', {
         'vertical-timeline-element--left': position === 'left',
@@ -44,53 +34,48 @@ const VerticalTimelineElement = ({
       })}
       style={style}
     >
-      <VisibilitySensor
-        {...visibilitySensorProps}
-        onChange={onVisibilitySensorChange}
-      >
-        <React.Fragment>
-          <span // eslint-disable-line jsx-a11y/no-static-element-interactions
-            style={iconStyle}
-            onClick={iconOnClick}
-            className={classNames(
-              iconClassName,
-              'vertical-timeline-element-icon',
-              {
-                'bounce-in': visible,
-                'is-hidden': !visible,
-              }
-            )}
-          >
-            {icon}
-          </span>
+      <React.Fragment>
+        <span // eslint-disable-line jsx-a11y/no-static-element-interactions
+          style={iconStyle}
+          onClick={iconOnClick}
+          className={classNames(
+            iconClassName,
+            'vertical-timeline-element-icon',
+            {
+              'bounce-in': inView,
+              'is-hidden': !inView,
+            }
+          )}
+        >
+          {icon}
+        </span>
+        <div
+          style={contentStyle}
+          onClick={onTimelineElementClick}
+          className={classNames(
+            textClassName,
+            'vertical-timeline-element-content',
+            {
+              'bounce-in': inView,
+              'is-hidden': !inView,
+            }
+          )}
+        >
           <div
-            style={contentStyle}
-            onClick={onTimelineElementClick}
+            style={contentArrowStyle}
+            className="vertical-timeline-element-content-arrow"
+          />
+          {children}
+          <span
             className={classNames(
-              textClassName,
-              'vertical-timeline-element-content',
-              {
-                'bounce-in': visible,
-                'is-hidden': !visible,
-              }
+              dateClassName,
+              'vertical-timeline-element-date'
             )}
           >
-            <div
-              style={contentArrowStyle}
-              className="vertical-timeline-element-content-arrow"
-            />
-            {children}
-            <span
-              className={classNames(
-                dateClassName,
-                'vertical-timeline-element-date'
-              )}
-            >
-              {date}
-            </span>
-          </div>
-        </React.Fragment>
-      </VisibilitySensor>
+            {date}
+          </span>
+        </div>
+      </React.Fragment>
     </div>
   );
 };
@@ -114,10 +99,9 @@ VerticalTimelineElement.propTypes = {
   position: PropTypes.string,
   style: PropTypes.shape({}),
   textClassName: PropTypes.string,
-  visibilitySensorProps: PropTypes.shape({
+  intersectionObserverProps: PropTypes.shape({
     onChange: PropTypes.func,
-    partialVisibility: PropTypes.bool,
-    offset: PropTypes.shape({}),
+    rootMargin: PropTypes.string,
   }),
 };
 
@@ -137,7 +121,7 @@ VerticalTimelineElement.defaultProps = {
   dateClassName: '',
   position: '',
   textClassName: '',
-  visibilitySensorProps: { partialVisibility: true, offset: { bottom: 40 } },
+  intersectionObserverProps: { rootMargin: '0px 0px 40px 0px' },
 };
 
 export default VerticalTimelineElement;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9157,6 +9157,13 @@ react-github-corner@^2.3.0:
   resolved "https://registry.yarnpkg.com/react-github-corner/-/react-github-corner-2.3.0.tgz#73ab17324b670c9cd955567b09663d385cfb05ef"
   integrity sha512-yVh8wtAfVA5CQYn8ygyxtsuCMoyiSEBVnzQJ3ynyWxZ1BzT2MHop4baZn/PnUnU9Yh8mwhLS5Y1RVxM5zNotGw==
 
+react-intersection-observer@^8.26.2:
+  version "8.26.2"
+  resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-8.26.2.tgz#0562ff0c06b2b10e809190c2fa9b6ded656e6e16"
+  integrity sha512-GmSjLNK+oV7kS+BHfrJSaA4wF61ELA33gizKHmN+tk59UT6/aW8kkqvlrFGPwxGoaIzLKS2evfG5fgkw5MIIsg==
+  dependencies:
+    tiny-invariant "^1.1.0"
+
 react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6, react-is@^16.9.0:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
@@ -9211,13 +9218,6 @@ react-transition-group@^4.3.0:
     dom-helpers "^5.0.1"
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
-
-react-visibility-sensor@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/react-visibility-sensor/-/react-visibility-sensor-5.1.1.tgz#5238380960d3a0b2be0b7faddff38541e337f5a9"
-  integrity sha512-cTUHqIK+zDYpeK19rzW6zF9YfT4486TIgizZW53wEZ+/GPBbK7cNS0EHyJVyHYacwFEvvHLEKfgJndbemWhB/w==
-  dependencies:
-    prop-types "^15.7.2"
 
 react@^16.9.0:
   version "16.12.0"
@@ -10565,6 +10565,11 @@ tiny-emitter@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
   integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
+
+tiny-invariant@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
+  integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
 
 tiny-warning@^1.0.2:
   version "1.0.3"


### PR DESCRIPTION
Hi, I started using your package. Its really awesome! While integrating with my app I noticed a few eslint issues and also saw that you could benefit from moving to `react-intersection-observer`. (https://github.com/stephane-monnot/react-vertical-timeline/issues/63)

Since you have saved me a bunch of time by providing this lovely package, I felt inspired to at least contribute back with some updates. Hope you find it helpful. 

**Fixes**

![Screen Shot 2020-05-25 at 4 58 21 PM](https://user-images.githubusercontent.com/5804876/82856391-b540fa80-9ec2-11ea-9d33-7494102b62bc.png)

* `dateClassName` was missing from `propTypes`.
* updates to use `useInView` hook for leveraging intersection observer
* updates jest tests to include `mockAllIsIntersecting`


One thing to note is that depending on your comfort level with browser support, `window.IntersectionObserver` is still relatively new, so you may want to include a polyfill. Browser support is pretty solid at this point, but up to you. Let me know if you want me to include that in this PR or not. 

Reference: https://github.com/thebuilder/react-intersection-observer#polyfill
Browser support: https://caniuse.com/#feat=intersectionobserver