### PR TITLE
fix: ie11 support

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -4,4 +4,9 @@ module.exports = {
     '@babel/preset-react',
   ],
   plugins: ['@babel/plugin-syntax-dynamic-import'],
+  env: {
+    modules: {
+      presets: ['@babel/preset-env'],
+    },
+  },
 };

--- a/package.json
+++ b/package.json
@@ -106,5 +106,10 @@
     "classnames": "^2.2.6",
     "prop-types": "^15.7.2",
     "react-intersection-observer": "^8.26.2"
-  }
+  },
+  "browserslist": [
+    "last 2 versions",
+    "> 1%",
+    "IE 11"
+  ]
 }


### PR DESCRIPTION
Now using browserlist when BABEL_ENV is modules, otherwise using existing node current target.