### PR TITLE
Fix icon alignment for large icons

### DIFF
--- a/src/VerticalTimelineElement.css
+++ b/src/VerticalTimelineElement.css
@@ -29,6 +29,9 @@
 }
 
 .vertical-timeline-element-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   position: absolute;
   top: 0;
   left: 0;
@@ -46,11 +49,6 @@
   display: block;
   width: 24px;
   height: 24px;
-  position: relative;
-  left: 50%;
-  top: 50%;
-  margin-left: -12px;
-  margin-top: -12px;
 }
 
 @media only screen and (min-width: 1170px) {


### PR DESCRIPTION
Icons larger than the default 24x24 are misaligned about 5px right of center. Flex resolves this issue by horizontally & vertically centering within the parent `span`.