### PR TITLE
fix date text alignment for two-column left timeline elements

### DIFF
--- a/src/VerticalTimelineElement.css
+++ b/src/VerticalTimelineElement.css
@@ -258,6 +258,7 @@
     top: 6px;
     font-size: 16px;
     font-size: 1rem;
+    text-align: left;
   }
 
   .vertical-timeline--two-columns .vertical-timeline-element:nth-child(even):not(.vertical-timeline-element--left) .vertical-timeline-element-content,


### PR DESCRIPTION
If someone's app's default text alignment is not left, then for VerticalTimelineElements with a left position, the date will be aligned accordingly within its column rather than next to the timeline icon.

The fix is to simply set `text-align: left;` so that date text will not inherit its alignment from parent elements.