### PR TITLE
Do not create empty space for event if `date` is null

### DIFF
--- a/src/VerticalTimelineElement.js
+++ b/src/VerticalTimelineElement.js
@@ -1,6 +1,6 @@
-import React from 'react';
-import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { InView } from 'react-intersection-observer';
 
 const VerticalTimelineElement = ({
@@ -71,14 +71,16 @@ const VerticalTimelineElement = ({
               className="vertical-timeline-element-content-arrow"
             />
             {children}
-            <span
-              className={classNames(
-                dateClassName,
-                'vertical-timeline-element-date'
-              )}
-            >
-              {date}
-            </span>
+            {date && (
+              <span
+                className={classNames(
+                  'vertical-timeline-element-date',
+                  dateClassName
+                )}
+              >
+                {date}
+              </span>
+            )}
           </div>
         </React.Fragment>
       </div>


### PR DESCRIPTION
Currently, if leave the optional `date` field as undefined, empty space will be rendered in the event timeline:
<img width="1324" alt="Screenshot 2023-08-29 at 20 54 13" src="https://github.com/stephane-monnot/react-vertical-timeline/assets/9114994/ffb532d7-782b-4d5e-b230-ce81459869ed">

This change add check before rendering it:
<img width="1362" alt="Screenshot 2023-08-29 at 20 53 44" src="https://github.com/stephane-monnot/react-vertical-timeline/assets/9114994/b5378d48-7eb0-405c-a0ee-4bb1f5292c6d">
