### PR TITLE
#173 img or other elements not centered, only svg centered

### DIFF
--- a/src/VerticalTimelineElement.css
+++ b/src/VerticalTimelineElement.css
@@ -52,7 +52,7 @@
   left: unset;
 }
 
-.vertical-timeline-element-icon svg {
+.vertical-timeline-element-icon * {
   display: block;
   width: 24px;
   height: 24px;


### PR DESCRIPTION
#173 fixed. `svg` replaced with `*` so whatever element passed in icon props of **VerticalTimelineElement**, it will be centered.